### PR TITLE
Preserve JS dependecies in Layout

### DIFF
--- a/IdentityServer.RazorViewEngine.Sample/UserViews/Layout.cshtml
+++ b/IdentityServer.RazorViewEngine.Sample/UserViews/Layout.cshtml
@@ -48,7 +48,7 @@
     @RenderBody()
 </div>
 
-<script src="@applicationPath/../Scripts/bootstrap.min.js"></script>
 <script src="@applicationPath/../Scripts/jquery-1.10.2.js"></script>
+<script src="@applicationPath/../Scripts/bootstrap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Bootstrap depends on JQuery, so it should be listed first in the Layout.cshtml
