### PR TITLE
Allow users to override the base RazorViewEngine

### DIFF
--- a/IdentityServer.RazorViewEngine/RazorViewService.cs
+++ b/IdentityServer.RazorViewEngine/RazorViewService.cs
@@ -26,32 +26,32 @@ namespace IdentityServer.RazorViewEngine
 			_service = RazorEngineService.Create(config);
 		}
 
-		public Task<Stream> Login(LoginViewModel model, SignInMessage message)
+		public virtual Task<Stream> Login(LoginViewModel model, SignInMessage message)
 		{
 			return Task.FromResult(RunTemplate("login", model, message.ClientId, message.Tenant));
 		}
 
-		public Task<Stream> Logout(LogoutViewModel model, SignOutMessage message)
+		public virtual Task<Stream> Logout(LogoutViewModel model, SignOutMessage message)
 		{
 			return Task.FromResult(RunTemplate("logout", model, message?.ClientId));
 		}
 
-		public Task<Stream> LoggedOut(LoggedOutViewModel model, SignOutMessage message)
+		public virtual Task<Stream> LoggedOut(LoggedOutViewModel model, SignOutMessage message)
 		{
 			return Task.FromResult(RunTemplate("loggedout", model, message?.ClientId));
 		}
 
-		public Task<Stream> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest)
+		public virtual Task<Stream> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest)
 		{
 			return Task.FromResult(RunTemplate("consent", model, authorizeRequest.ClientId));
 		}
 
-		public Task<Stream> ClientPermissions(ClientPermissionsViewModel model)
+		public virtual Task<Stream> ClientPermissions(ClientPermissionsViewModel model)
 		{
 			return Task.FromResult(RunTemplate("permission", model));
 		}
 
-		public Task<Stream> Error(ErrorViewModel model)
+		public virtual Task<Stream> Error(ErrorViewModel model)
 		{
 			return Task.FromResult(RunTemplate("error", model));
 		}


### PR DESCRIPTION
Currently, you can't derive from the base RazorViewEngine and override the base methods. IdentityServer allows you to derive and override their DefaultViewService. It'd be nice to have this functionality continued using Razor as well.

See: https://github.com/IdentityServer/IdentityServer3/blob/master/source/Core/Services/DefaultViewService/DefaultViewService.cs
