### PR TITLE
Replace ng-src with src for image

### DIFF
--- a/IdentityServer.RazorViewEngine.Sample/UserViews/Permission.cshtml
+++ b/IdentityServer.RazorViewEngine.Sample/UserViews/Permission.cshtml
@@ -38,7 +38,7 @@
     {
         <div class="row permission">
             <div class="col-sm-2">
-                <img ng-src="@client.ClientLogoUrl">
+                <img src="@client.ClientLogoUrl">
             </div>
             <div class="col-sm-8">
                 <div class="permission-clientname">@client.ClientName</div>


### PR DESCRIPTION
Client Logos weren't appearing on the permission page due to a remnant of the base angular view.
