### PR TITLE
Make IdentityTemplateKey public

### DIFF
--- a/IdentityServer.RazorViewEngine/IdentityTemplateKey.cs
+++ b/IdentityServer.RazorViewEngine/IdentityTemplateKey.cs
@@ -3,7 +3,7 @@ using RazorEngine.Templating;
 
 namespace IdentityServer.RazorViewEngine
 {
-	class IdentityTemplateKey : ITemplateKey
+	public class IdentityTemplateKey : ITemplateKey
 	{
 		public IdentityTemplateKey(string name, 
 		                           string clientId,


### PR DESCRIPTION
Making the IdentityTemplateKey public allows a developer to extend the IdentityTemplateManager to a custom view service. This is useful for rendering custom Identity views, such as a registration page or password reset page.
