### PR TITLE
Inherited RazorViewService from DefaultViewService

### DIFF
--- a/IdentityServer.RazorViewEngine/IdentityServer.RazorViewEngine.csproj
+++ b/IdentityServer.RazorViewEngine/IdentityServer.RazorViewEngine.csproj
@@ -31,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="IdentityServer3, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IdentityServer3.2.1.1\lib\net45\IdentityServer3.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="IdentityServer3, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.4.0\lib\net45\IdentityServer3.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/IdentityServer.RazorViewEngine/RazorViewService.cs
+++ b/IdentityServer.RazorViewEngine/RazorViewService.cs
@@ -16,47 +16,52 @@ using RazorEngine.Templating;
 
 namespace IdentityServer.RazorViewEngine
 {
-	public class RazorViewService : IViewService
+	public class RazorViewService : DefaultViewService
 	{
 		private readonly IRazorEngineService _service;
 
-		public RazorViewService(TemplateServiceConfiguration config)
-		{
+		public RazorViewService(TemplateServiceConfiguration config) : base(new DefaultViewServiceOptions(), new EmbeddedAssetsViewLoader())
+		{            
 			config.Debug = true;
 			_service = RazorEngineService.Create(config);
 		}
 
-		public virtual Task<Stream> Login(LoginViewModel model, SignInMessage message)
+		public override Task<Stream> Login(LoginViewModel model, SignInMessage message)
 		{
 			return Task.FromResult(RunTemplate("login", model, message.ClientId, message.Tenant));
 		}
 
-		public virtual Task<Stream> Logout(LogoutViewModel model, SignOutMessage message)
+        public override Task<Stream> Logout(LogoutViewModel model, SignOutMessage message)
 		{
 			return Task.FromResult(RunTemplate("logout", model, message?.ClientId));
 		}
 
-		public virtual Task<Stream> LoggedOut(LoggedOutViewModel model, SignOutMessage message)
+        public override Task<Stream> LoggedOut(LoggedOutViewModel model, SignOutMessage message)
 		{
 			return Task.FromResult(RunTemplate("loggedout", model, message?.ClientId));
 		}
 
-		public virtual Task<Stream> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest)
+        public override Task<Stream> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest)
 		{
 			return Task.FromResult(RunTemplate("consent", model, authorizeRequest.ClientId));
 		}
 
-		public virtual Task<Stream> ClientPermissions(ClientPermissionsViewModel model)
+        public virtual Task<Stream> ClientPermissions(ClientPermissionsViewModel model)
 		{
 			return Task.FromResult(RunTemplate("permission", model));
 		}
 
-		public virtual Task<Stream> Error(ErrorViewModel model)
+        public override Task<Stream> Error(ErrorViewModel model)
 		{
 			return Task.FromResult(RunTemplate("error", model));
 		}
 
-		protected Stream RunTemplate(string key, object model, string clientId = null, string tenant = null)
+        public override Task<Stream> AuthorizeResponse(AuthorizeResponseViewModel model)
+        {
+            return Task.FromResult(RunTemplate("formpostresponse", model));
+        }
+
+        protected Stream RunTemplate(string key, object model, string clientId = null, string tenant = null)
 	        {
 	            var viewBag = new DynamicViewBag(new Dictionary<string, object>
 	            {

--- a/IdentityServer.RazorViewEngine/packages.config
+++ b/IdentityServer.RazorViewEngine/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IdentityServer3" version="2.1.1" targetFramework="net45" />
+  <package id="IdentityServer3" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="RazorEngine" version="3.7.3" targetFramework="net45" />


### PR DESCRIPTION
I've changed the RazorViewService so it inherits DefaultViewService, allowing to customize the AuthorizeResponse view (see [this issue for IdentityServer3](https://github.com/IdentityServer/IdentityServer3/issues/2124)). This really needs a review because it's just a quick hack, but it seems to work.